### PR TITLE
Startup code for arm 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# IDEs
+.vscode/
+archives/
+
+# GDB
+*/**/.gdb_history
+
+# Artifacts
+build/
+.DS_Store
+
+*.json
+
+.cache

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ To build the project:
 ```bash
 conan build . -pr <target_name> -pr <compiler>
 ```
+For the `lpc4078 micro mod`:
 
 For the `lpc4078`
-
+```bash
+conan build . -pr mod-lpc-v5 -pr arm-gcc-12.3
+```
 ```bash
 conan build . -pr lpc4078 -pr arm-gcc-12.3
 ```
+
 
 For the STM32F103 MicroMod V4:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # urc-control-systems-2024
 This Repository will host the code for the new SJSU Robotics Rover.
+To build: 
+To build the project:
+### Note: the LPC4078 and stm32f1 platforms are not included, simply the micromod in the arm subsystem. 
+```bash
+conan build . -pr <target_name> -pr <compiler>
+```
+
+For the `lpc4078`
+
+```bash
+conan build . -pr lpc4078 -pr arm-gcc-12.3
+```
+
+For the STM32F103 MicroMod V4:
+
+```bash
+conan build . -pr mod-stm32f1-v4 -pr arm-gcc-12.3
+```
+
+## Installing Platform Profiles
+
+`lpc40` profiles:
+
+```bash
+conan config install -sf conan/profiles/v2 -tf profiles https://github.com/libhal/libhal-lpc40.git
+```
+
+`stm32f1` profiles:
+
+```bash
+conan config install -sf conan/profiles/v2 -tf profiles https://github.com/libhal/libhal-stm32f1.git
+```
+
+`micromod` profiles:
+
+```bash
+conan config install -sf conan/profiles/v1 -tf profiles https://github.com/libhal/libhal-micromod.git
+```

--- a/arm/CMakeLists.txt
+++ b/arm/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.25)
+
+# Set project name to demos
+project(application LANGUAGES CXX)
+
+libhal_build_demos(
+    DEMOS
+    application
+
+)

--- a/arm/CMakeLists.txt
+++ b/arm/CMakeLists.txt
@@ -1,49 +1,10 @@
-# Copyright 2024 Khalil Estell
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 cmake_minimum_required(VERSION 3.25)
 
-project(app.elf LANGUAGES CXX)
+# Set project name to demos
+project(application LANGUAGES CXX)
 
-set(platform_library $ENV{LIBHAL_PLATFORM_LIBRARY})
-set(platform $ENV{LIBHAL_PLATFORM})
+libhal_build_demos(
+    DEMOS
+    application
 
-if("${platform_library}" STREQUAL "")
-    message(FATAL_ERROR
-        "Build environment variable LIBHAL_PLATFORM_LIBRARY is required for " "this project.")
-endif()
-
-if("${platform}" STREQUAL "")
-    message(FATAL_ERROR
-        "Build environment variable LIBHAL_PLATFORM is required for "
-        "this project.")
-endif()
-
-find_package(libhal-${platform_library} REQUIRED CONFIG)
-find_package(libhal-util REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME}
-    main.cpp
-    applications/application.cpp
-    platforms/${platform}.cpp
 )
-
-target_compile_options(${PROJECT_NAME} PRIVATE -g -Wall -Wextra)
-target_include_directories(${PROJECT_NAME} PUBLIC include)
-target_link_libraries(${PROJECT_NAME} PRIVATE
-    libhal::${platform_library}
-    libhal::util)
-
-libhal_post_build(${PROJECT_NAME})
-libhal_disassemble(${PROJECT_NAME})

--- a/arm/CMakeLists.txt
+++ b/arm/CMakeLists.txt
@@ -1,10 +1,49 @@
+# Copyright 2024 Khalil Estell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.25)
 
-# Set project name to demos
-project(application LANGUAGES CXX)
+project(app.elf LANGUAGES CXX)
 
-libhal_build_demos(
-    DEMOS
-    application
+set(platform_library $ENV{LIBHAL_PLATFORM_LIBRARY})
+set(platform $ENV{LIBHAL_PLATFORM})
 
+if("${platform_library}" STREQUAL "")
+    message(FATAL_ERROR
+        "Build environment variable LIBHAL_PLATFORM_LIBRARY is required for " "this project.")
+endif()
+
+if("${platform}" STREQUAL "")
+    message(FATAL_ERROR
+        "Build environment variable LIBHAL_PLATFORM is required for "
+        "this project.")
+endif()
+
+find_package(libhal-${platform_library} REQUIRED CONFIG)
+find_package(libhal-util REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME}
+    main.cpp
+    applications/application.cpp
+    platforms/${platform}.cpp
 )
+
+target_compile_options(${PROJECT_NAME} PRIVATE -g -Wall -Wextra)
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    libhal::${platform_library}
+    libhal::util)
+
+libhal_post_build(${PROJECT_NAME})
+libhal_disassemble(${PROJECT_NAME})

--- a/arm/applications/application.cpp
+++ b/arm/applications/application.cpp
@@ -1,4 +1,3 @@
-#include <chrono>
 
 #include <libhal-exceptions/control.hpp>
 #include <libhal-util/serial.hpp>

--- a/arm/applications/application.cpp
+++ b/arm/applications/application.cpp
@@ -1,0 +1,41 @@
+#include <chrono>
+
+#include <libhal-exceptions/control.hpp>
+#include <libhal-util/serial.hpp>
+#include <libhal-util/steady_clock.hpp>
+#include <libhal/error.hpp>
+#include <libhal/steady_clock.hpp>
+
+#include "./application.hpp"
+
+
+namespace sjsu::arm {
+void application(hardware_map_t& hardware_map)
+{
+  using namespace std::chrono_literals;
+
+  auto& led = *hardware_map.led;
+  auto& clock = *hardware_map.clock;
+  auto& console = *hardware_map.console;
+
+  hal::print(console, "Starting Application!\n");
+  hal::print(console, "Will reset after ~10 seconds\n");
+
+  for (int i = 0; i < 10; i++) {
+    // Print message
+    hal::print(console, "Hello, World\n");
+
+    // Toggle LED
+    led.level(true);
+    hal::delay(clock, 500ms);
+
+    led.level(false);
+    hal::delay(clock, 500ms);
+  }
+
+  hal::print(console, "Resetting!\n");
+  hal::delay(clock, 100ms);
+  hardware_map.reset();
+
+}
+}

--- a/arm/applications/application.hpp
+++ b/arm/applications/application.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <libhal/functional.hpp>
+#include <libhal/output_pin.hpp>
+#include <libhal/serial.hpp>
+#include <libhal/steady_clock.hpp>
+namespace sjsu::arm {
+struct hardware_map_t
+{
+  hal::output_pin* led;
+  hal::serial* console;
+  hal::steady_clock* clock;
+  hal::callback<void()> reset;
+};
+
+// Application function must be implemented by one of the compilation units
+// (.cpp) files.
+void initialize_processor();
+hardware_map_t initialize_platform();
+void application(hardware_map_t& p_framework);
+}

--- a/arm/conanfile.py
+++ b/arm/conanfile.py
@@ -1,0 +1,12 @@
+from conan import ConanFile
+
+required_conan_version = ">=2.0.14"
+
+
+class demos(ConanFile):
+    python_requires = "libhal-bootstrap/[^2.1.1]"
+    python_requires_extend = "libhal-bootstrap.demo"
+
+    def requirements(self):
+        bootstrap = self.python_requires["libhal-bootstrap"]
+        bootstrap.module.add_demo_requirements(self)

--- a/arm/main.cpp
+++ b/arm/main.cpp
@@ -1,0 +1,24 @@
+#include <libhal/error.hpp>
+
+#include "applications/application.hpp"
+
+sjsu::arm::hardware_map_t hardware_map{};
+
+int main()
+{
+  try {
+    hardware_map = sjsu::arm::initialize_platform();
+  } catch (...) {
+    hal::halt();
+  }
+
+  sjsu::arm::application(hardware_map);
+  return 0;
+}
+
+// TODO(#129) remove this later (used in building for debug) 
+extern "C" {
+  _reent* _impure_ptr = nullptr;
+  void __assert_func() {
+  }
+}

--- a/arm/platforms/micromod.cpp
+++ b/arm/platforms/micromod.cpp
@@ -1,7 +1,9 @@
 #include <libhal-micromod/micromod.hpp>
 
-#include "../applications/applications.hpp"
-namespace sjsu::arm{
+#include "../applications/application.hpp"
+
+namespace sjsu::arm {
+
 hardware_map_t initialize_platform()
 {
   using namespace hal::literals;

--- a/arm/platforms/micromod.cpp
+++ b/arm/platforms/micromod.cpp
@@ -1,0 +1,18 @@
+#include <libhal-micromod/micromod.hpp>
+
+#include "../applications/applications.hpp"
+namespace sjsu::arm{
+hardware_map_t initialize_platform()
+{
+  using namespace hal::literals;
+
+  hal::micromod::v1::initialize_platform();
+
+  return {
+    .led = &hal::micromod::v1::led(),
+    .console = &hal::micromod::v1::console(hal::buffer<128>),
+    .clock = &hal::micromod::v1::uptime_clock(),
+    .reset = +[]() { hal::micromod::v1::reset(); },
+  };
+}
+}

--- a/arm/platforms/micromod.cpp
+++ b/arm/platforms/micromod.cpp
@@ -11,7 +11,7 @@ hardware_map_t initialize_platform()
   hal::micromod::v1::initialize_platform();
 
   return {
-    .led = &hal::micromod::v1::led(),
+    .led = &hal::micromod::v1::led(), 
     .console = &hal::micromod::v1::console(hal::buffer<128>),
     .clock = &hal::micromod::v1::uptime_clock(),
     .reset = +[]() { hal::micromod::v1::reset(); },


### PR DESCRIPTION
- Includes basic startup code for other subsystems to use. 
- the platforms file now only has the micromod implementation. We can also add the implementation for LPC4078 and STMf1 when we need. 