### PR TITLE
Asynchronous Homing

### DIFF
--- a/drive/applications/chassis_vel_demo.cpp
+++ b/drive/applications/chassis_vel_demo.cpp
@@ -19,7 +19,7 @@ void application()
     drivetrain dt(resources::swerve_modules(),
                   hal_time_duration_to_sec(refresh_rate));
 
-    dt.async_home_begin();
+    dt.hard_home();
 
     dt.set_target_state(chassis_velocities(vector2d(0, 0), 1), true);
     hal::print<128>(*console,

--- a/drive/applications/chassis_vel_demo.cpp
+++ b/drive/applications/chassis_vel_demo.cpp
@@ -19,7 +19,7 @@ void application()
     drivetrain dt(resources::swerve_modules(),
                   hal_time_duration_to_sec(refresh_rate));
 
-    dt.hard_home();
+    dt.hard_home(clock);
 
     dt.set_target_state(chassis_velocities(vector2d(0, 0), 1), true);
     hal::print<128>(*console,

--- a/drive/applications/chassis_vel_demo.cpp
+++ b/drive/applications/chassis_vel_demo.cpp
@@ -18,7 +18,11 @@ void application()
   constexpr int delay_cycles = transition_time / refresh_rate;
   drivetrain dt(resources::swerve_modules(),
                 hal_time_duration_to_sec(refresh_rate));
-  dt.hard_home();
+
+  dt.hard_home_begin();
+  while (!dt.hard_home_poll()) {
+    hal::delay(*clock, 250ms);
+  }
 
   dt.set_target_state(chassis_velocities(vector2d(0, 0), 1), true);
   hal::print<128>(*console,

--- a/drive/applications/chassis_vel_demo.cpp
+++ b/drive/applications/chassis_vel_demo.cpp
@@ -12,119 +12,116 @@ void application()
   auto clock = resources::clock();
   auto console = resources::console();
   try {
-  using namespace std::chrono_literals;
-  constexpr auto refresh_rate = 250ms;
-  constexpr auto transition_time = 5s;
-  constexpr int delay_cycles = transition_time / refresh_rate;
-  drivetrain dt(resources::swerve_modules(),
-                hal_time_duration_to_sec(refresh_rate));
+    using namespace std::chrono_literals;
+    constexpr auto refresh_rate = 250ms;
+    constexpr auto transition_time = 5s;
+    constexpr int delay_cycles = transition_time / refresh_rate;
+    drivetrain dt(resources::swerve_modules(),
+                  hal_time_duration_to_sec(refresh_rate));
 
-  dt.async_home_begin();
-  while (!dt.async_home_poll()) {
-    hal::delay(*clock, 250ms);
-  }
+    dt.async_home_begin();
 
-  dt.set_target_state(chassis_velocities(vector2d(0, 0), 1), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(1, 0), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(0, 1), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(0, 1), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(1, 0), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(0, 0), 1), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
-  hal::print<128>(*console,
-                  "v:%f,%f,%f\n",
-                  dt.get_target_state().translation.x,
-                  dt.get_target_state().translation.y,
-                  dt.get_target_state().rotational_vel);
-  for (int i = 0; i < delay_cycles; i++) {
-    dt.periodic();
-    hal::delay(*clock, refresh_rate);
-  }
-  hal::print(*console,"fin!");
+    dt.set_target_state(chassis_velocities(vector2d(0, 0), 1), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(1, 0), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(0, 1), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(0, 1), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(1, 0), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(0, 0), 1), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    dt.set_target_state(chassis_velocities(vector2d(0, 0), 0), true);
+    hal::print<128>(*console,
+                    "v:%f,%f,%f\n",
+                    dt.get_target_state().translation.x,
+                    dt.get_target_state().translation.y,
+                    dt.get_target_state().rotational_vel);
+    for (int i = 0; i < delay_cycles; i++) {
+      dt.periodic();
+      hal::delay(*clock, refresh_rate);
+    }
+    hal::print(*console, "fin!");
   } catch (hal::exception e) {
     hal::print<128>(*console, "Exception code %d\n", e.error_code());
   }

--- a/drive/applications/chassis_vel_demo.cpp
+++ b/drive/applications/chassis_vel_demo.cpp
@@ -19,8 +19,8 @@ void application()
   drivetrain dt(resources::swerve_modules(),
                 hal_time_duration_to_sec(refresh_rate));
 
-  dt.hard_home_begin();
-  while (!dt.hard_home_poll()) {
+  dt.async_home_begin();
+  while (!dt.async_home_poll()) {
     hal::delay(*clock, 250ms);
   }
 

--- a/drive/applications/drive_cycle_demo.cpp
+++ b/drive/applications/drive_cycle_demo.cpp
@@ -34,7 +34,7 @@ void application()
   auto clock = resources::clock();
   drivetrain dt(resources::swerve_modules(), cycle_time_sec);
 
-  dt.hard_home();
+  dt.hard_home(clock);
 
   hal::time_duration loop_duration = 0ns;
   for (unsigned int i = 0; i < sizeof(states) / sizeof(states[0]); i++) {

--- a/drive/applications/drive_cycle_demo.cpp
+++ b/drive/applications/drive_cycle_demo.cpp
@@ -33,8 +33,8 @@ void application()
   constexpr sec cycle_time_sec = hal_time_duration_to_sec(cycle_time);
   auto clock = resources::clock();
   drivetrain dt(resources::swerve_modules(), cycle_time_sec);
-  dt.hard_home_begin();
-  while (!dt.hard_home_poll()) {
+  dt.async_home_begin();
+  while (!dt.async_home_poll()) {
     hal::delay(*clock, 250ms);
   }
 

--- a/drive/applications/drive_cycle_demo.cpp
+++ b/drive/applications/drive_cycle_demo.cpp
@@ -33,7 +33,10 @@ void application()
   constexpr sec cycle_time_sec = hal_time_duration_to_sec(cycle_time);
   auto clock = resources::clock();
   drivetrain dt(resources::swerve_modules(), cycle_time_sec);
-  dt.hard_home();
+  dt.hard_home_begin();
+  while (!dt.hard_home_poll()) {
+    hal::delay(*clock, 250ms);
+  }
 
   hal::time_duration loop_duration = 0ns;
   for (unsigned int i = 0; i < sizeof(states) / sizeof(states[0]); i++) {

--- a/drive/applications/drive_cycle_demo.cpp
+++ b/drive/applications/drive_cycle_demo.cpp
@@ -1,4 +1,3 @@
-#include <swerve_module.hpp>
 #include <drivetrain.hpp>
 #include <drivetrain_math.hpp>
 #include <libhal-exceptions/control.hpp>
@@ -7,6 +6,7 @@
 #include <libhal/error.hpp>
 #include <libhal/units.hpp>
 #include <resource_list.hpp>
+#include <swerve_module.hpp>
 
 namespace sjsu::drive {
 
@@ -33,10 +33,8 @@ void application()
   constexpr sec cycle_time_sec = hal_time_duration_to_sec(cycle_time);
   auto clock = resources::clock();
   drivetrain dt(resources::swerve_modules(), cycle_time_sec);
-  dt.async_home_begin();
-  while (!dt.async_home_poll()) {
-    hal::delay(*clock, 250ms);
-  }
+
+  dt.hard_home();
 
   hal::time_duration loop_duration = 0ns;
   for (unsigned int i = 0; i < sizeof(states) / sizeof(states[0]); i++) {

--- a/drive/applications/sequential_homing_demo.cpp
+++ b/drive/applications/sequential_homing_demo.cpp
@@ -19,7 +19,7 @@ void application()
     hal::print(*console, "starting homing!\n");
     for (int i = 0; i < module_count; i++) {
       try {
-        (*swerve_modules)[i]->hard_home_begin();
+        (*swerve_modules)[i]->async_home_begin();
       } catch (hal::exception e) {
         hal::print<64>(*console, "Wheel home throwing error %d\n", i);
         throw e;
@@ -29,14 +29,14 @@ void application()
       bool homed = true;
       for (int i = 0; i < module_count; i++) {
         try {
-          switch (swerve_modules->at(i)->hard_home_poll()) {
-            case hard_home_status::in_progress:
+          switch (swerve_modules->at(i)->async_home_poll()) {
+            case async_home_status::in_progress:
               homed = false;
               break;
-            case hard_home_status::completed:
+            case async_home_status::completed:
               hal::print<64>(*console, "Wheel homed %d\n", i);
               break;
-            case hard_home_status::inactive:
+            case async_home_status::inactive:
               break;
           }
           // swerve_modules->at(i)->set_target_state(swerve_module_state(0, 0));

--- a/drive/applications/sequential_homing_demo.cpp
+++ b/drive/applications/sequential_homing_demo.cpp
@@ -1,3 +1,4 @@
+#include "swerve_module.hpp"
 #include <drivetrain_math.hpp>
 #include <libhal-exceptions/control.hpp>
 #include <libhal-util/serial.hpp>
@@ -16,16 +17,38 @@ void application()
     auto swerve_modules = resources::swerve_modules();
     hal::print(*console, "modules defined\n");
     hal::print(*console, "starting homing!\n");
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < module_count; i++) {
       try {
-        swerve_modules->at(i)->hard_home();
-        hal::print<64>(*console, "Homed wheel: %d\n", i);
-        // swerve_modules->at(i)->set_target_state(swerve_module_state(0, 0));
+        (*swerve_modules)[i]->hard_home_begin();
       } catch (hal::exception e) {
-        hal::print<64>(
-          *console, "Wheel %d throwing error %d\n", i, e.error_code());
+        hal::print<64>(*console, "Wheel home throwing error %d\n", i);
         throw e;
       }
+    }
+    while (true) {
+      bool homed = true;
+      for (int i = 0; i < module_count; i++) {
+        try {
+          switch (swerve_modules->at(i)->hard_home_poll()) {
+            case hard_home_status::in_progress:
+              homed = false;
+              break;
+            case hard_home_status::completed:
+              hal::print<64>(*console, "Wheel homed %d\n", i);
+              break;
+            case hard_home_status::inactive:
+              break;
+          }
+          // swerve_modules->at(i)->set_target_state(swerve_module_state(0, 0));
+        } catch (hal::exception e) {
+          hal::print<64>(*console, "Wheel home poll throwing error %d\n", i);
+          throw e;
+        }
+      }
+      if (homed) {
+        break;
+      }
+      hal::delay(*clock, 250ms);  // supposedly safe
     }
   } catch (hal::exception e) {
     hal::print<128>(*console, "Exception code %d\n", e.error_code());

--- a/drive/applications/simple_state_set_demo.cpp
+++ b/drive/applications/simple_state_set_demo.cpp
@@ -20,7 +20,7 @@ void application()
 
     for (int i = 0; i < module_count; i++) {
       try {
-        (*swerve_modules)[i]->hard_home_begin();
+        (*swerve_modules)[i]->async_home_begin();
       } catch (hal::exception e) {
         hal::print<64>(*console, "Wheel home throwing error %d\n", i);
         throw e;
@@ -30,14 +30,14 @@ void application()
       bool homed = true;
       for (int i = 0; i < module_count; i++) {
         try {
-          switch ((*swerve_modules)[i]->hard_home_poll()) {
-            case hard_home_status::in_progress:
+          switch ((*swerve_modules)[i]->async_home_poll()) {
+            case async_home_status::in_progress:
               homed = false;
               break;
-            case hard_home_status::completed:
+            case async_home_status::completed:
               hal::print<64>(*console, "Wheel homed %d\n", i);
               break;
-            case hard_home_status::inactive:
+            case async_home_status::inactive:
               break;
           }
         } catch (hal::exception e) {

--- a/drive/applications/simple_state_set_demo.cpp
+++ b/drive/applications/simple_state_set_demo.cpp
@@ -1,10 +1,10 @@
-#include <swerve_module.hpp>
 #include <drivetrain_math.hpp>
 #include <libhal-exceptions/control.hpp>
 #include <libhal-util/serial.hpp>
 #include <libhal-util/steady_clock.hpp>
 #include <libhal/error.hpp>
 #include <resource_list.hpp>
+#include <swerve_module.hpp>
 
 namespace sjsu::drive {
 void application()
@@ -17,17 +17,42 @@ void application()
     auto swerve_modules = resources::swerve_modules();
     hal::print(*console, "modules defined\n");
     hal::print(*console, "starting homing!\n");
+
     for (int i = 0; i < module_count; i++) {
       try {
-        (*swerve_modules)[i]->hard_home();
-        hal::print<64>(*console, "Homed wheel: %d\n", i);
+        (*swerve_modules)[i]->hard_home_begin();
       } catch (hal::exception e) {
-        hal::print<64>(*console, "Wheel throwing error %d\n", i);
+        hal::print<64>(*console, "Wheel home throwing error %d\n", i);
         throw e;
       }
     }
+    while (true) {
+      bool homed = true;
+      for (int i = 0; i < module_count; i++) {
+        try {
+          switch ((*swerve_modules)[i]->hard_home_poll()) {
+            case hard_home_status::in_progress:
+              homed = false;
+              break;
+            case hard_home_status::completed:
+              hal::print<64>(*console, "Wheel homed %d\n", i);
+              break;
+            case hard_home_status::inactive:
+              break;
+          }
+        } catch (hal::exception e) {
+          hal::print<64>(*console, "Wheel home poll throwing error %d\n", i);
+          throw e;
+        }
+      }
+      if (homed) {
+        break;
+      }
+      hal::delay(*clock, 250ms);  // supposedly safe
+    }
+
     for (int i = 0; i < module_count; i++) {
-      (*swerve_modules)[i]->set_target_state(swerve_module_state(0,0));
+      (*swerve_modules)[i]->set_target_state(swerve_module_state(0, 0));
     }
     hal::delay(*clock, 10s);
     while (true) {

--- a/drive/include/drivetrain.hpp
+++ b/drive/include/drivetrain.hpp
@@ -57,8 +57,9 @@ public:
    */
   bool aligned();
   /**
-   * @brief begin homing asynchronously, *you must call async_home_poll* in a
-   * loop with a delay of <= 250ms otherwise the limit switches may break!
+   * @brief begin homing asynchronously, polling for "homing stop" is done
+   * automatically within periodic() so you should not call async_home_begin()
+   * without calling periodic() in a loop!
    */
   void async_home_begin();
   /**
@@ -77,7 +78,10 @@ private:
   chassis_velocities m_target_state;
   bool m_resolve_module_conflicts = false;
   bool m_stopping = false;
-  void async_home_poll();
+  /**
+   * @return true if at least one swerve module is currently homing.
+   */
+  bool async_home_poll();
 };
 
 }  // namespace sjsu::drive

--- a/drive/include/drivetrain.hpp
+++ b/drive/include/drivetrain.hpp
@@ -62,12 +62,6 @@ public:
    */
   void async_home_begin();
   /**
-   * @brief poll limit switches, if active it will stop homing.
-   *
-   * @return true if hard homing is complete.
-   */
-  bool async_home_poll();
-  /**
    * @brief stops homing immediately on all motors, regardless if they are
    * currently homing or not.
    */
@@ -83,6 +77,7 @@ private:
   chassis_velocities m_target_state;
   bool m_resolve_module_conflicts = false;
   bool m_stopping = false;
+  void async_home_poll();
 };
 
 }  // namespace sjsu::drive

--- a/drive/include/drivetrain.hpp
+++ b/drive/include/drivetrain.hpp
@@ -67,6 +67,11 @@ public:
    * @return true if hard homing is complete.
    */
   bool async_home_poll();
+  /**
+   * @brief stops homing immediately on all motors, regardless if they are
+   * currently homing or not.
+   */
+  void async_home_stop();
 
 private:
   hal::v5::strong_ptr<

--- a/drive/include/drivetrain.hpp
+++ b/drive/include/drivetrain.hpp
@@ -57,10 +57,16 @@ public:
    */
   bool aligned();
   /**
-   * @brief with run homing in a fixed loop (will not update other motors or get
-   * interupted)
+   * @brief begin homing asynchronously, *you must call hard_home_poll* in a
+   * loop with a delay of <= 250ms otherwise the limit switches may break!
    */
-  void hard_home();
+  void hard_home_begin();
+  /**
+   * @brief poll limit switches, if active it will stop homing.
+   *
+   * @return true if hard homing is complete.
+   */
+  bool hard_home_poll();
 
 private:
   hal::v5::strong_ptr<

--- a/drive/include/drivetrain.hpp
+++ b/drive/include/drivetrain.hpp
@@ -57,6 +57,10 @@ public:
    */
   bool aligned();
   /**
+   * @brief synchronously home, blocks thread until homing is finished.
+   */
+  void hard_home();
+  /**
    * @brief begin homing asynchronously, polling for "homing stop" is done
    * automatically within periodic() so you should not call async_home_begin()
    * without calling periodic() in a loop!

--- a/drive/include/drivetrain.hpp
+++ b/drive/include/drivetrain.hpp
@@ -59,7 +59,7 @@ public:
   /**
    * @brief synchronously home, blocks thread until homing is finished.
    */
-  void hard_home();
+  void hard_home(hal::v5::strong_ptr<hal::steady_clock> p_clock);
   /**
    * @brief begin homing asynchronously, polling for "homing stop" is done
    * automatically within periodic() so you should not call async_home_begin()

--- a/drive/include/drivetrain.hpp
+++ b/drive/include/drivetrain.hpp
@@ -57,16 +57,16 @@ public:
    */
   bool aligned();
   /**
-   * @brief begin homing asynchronously, *you must call hard_home_poll* in a
+   * @brief begin homing asynchronously, *you must call async_home_poll* in a
    * loop with a delay of <= 250ms otherwise the limit switches may break!
    */
-  void hard_home_begin();
+  void async_home_begin();
   /**
    * @brief poll limit switches, if active it will stop homing.
    *
    * @return true if hard homing is complete.
    */
-  bool hard_home_poll();
+  bool async_home_poll();
 
 private:
   hal::v5::strong_ptr<

--- a/drive/include/swerve_module.hpp
+++ b/drive/include/swerve_module.hpp
@@ -137,7 +137,7 @@ private:
   // true = out of tolerance
   bool m_stable_tolerance_state = false;
   // true if currently hard homing
-  bool m_hard_homing_state = false;
+  bool m_async_homing_state = false;
 
 private:
 };

--- a/drive/include/swerve_module.hpp
+++ b/drive/include/swerve_module.hpp
@@ -33,6 +33,12 @@ struct swerve_module_settings
   bool drive_forward_clockwise = true;
 };
 
+enum hard_home_status {
+  inactive,
+  in_progress,
+  completed,
+};
+
 class swerve_module
 {
 public:
@@ -104,10 +110,18 @@ public:
    */
   bool tolerance_timed_out() const;
   /**
-   * @brief with run homing in a fixed loop (will not update other motors or get
-   * interupted)
+   * @brief begin homing asynchronously, *you must call hard_home_poll* in a
+   * loop with a delay of <= 250ms otherwise the limit switches may break!
    */
-  void hard_home();
+  void hard_home_begin();
+  /**
+   * @brief poll limit switches, if active it will stop homing.
+   *
+   * @return current hard homing status. completed is fired when this function
+   * detects the limit switch is hit and stops the motors; after completed is
+   * fired, poll will return inactive for this module.
+   */
+  hard_home_status hard_home_poll();
 
 private:
   hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> m_steer_motor;
@@ -122,6 +136,8 @@ private:
   hal::time_duration m_tolerance_last_changed = 0ns;
   // true = out of tolerance
   bool m_stable_tolerance_state = false;
+  // true if currently hard homing
+  bool m_hard_homing_state = false;
 
 private:
 };

--- a/drive/include/swerve_module.hpp
+++ b/drive/include/swerve_module.hpp
@@ -122,6 +122,11 @@ public:
    * fired, poll will return inactive for this module.
    */
   async_home_status async_home_poll();
+  /**
+   * @brief stops homing immediately by setting motor velocity to 0 and homing
+   * state to false regardless if homing state is active or not.
+   */
+  void async_home_stop();
 
 private:
   hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> m_steer_motor;

--- a/drive/include/swerve_module.hpp
+++ b/drive/include/swerve_module.hpp
@@ -33,7 +33,7 @@ struct swerve_module_settings
   bool drive_forward_clockwise = true;
 };
 
-enum hard_home_status {
+enum async_home_status {
   inactive,
   in_progress,
   completed,
@@ -110,10 +110,10 @@ public:
    */
   bool tolerance_timed_out() const;
   /**
-   * @brief begin homing asynchronously, *you must call hard_home_poll* in a
+   * @brief begin homing asynchronously, *you must call async_home_poll* in a
    * loop with a delay of <= 250ms otherwise the limit switches may break!
    */
-  void hard_home_begin();
+  void async_home_begin();
   /**
    * @brief poll limit switches, if active it will stop homing.
    *
@@ -121,7 +121,7 @@ public:
    * detects the limit switch is hit and stops the motors; after completed is
    * fired, poll will return inactive for this module.
    */
-  hard_home_status hard_home_poll();
+  async_home_status async_home_poll();
 
 private:
   hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> m_steer_motor;

--- a/drive/include/swerve_module.hpp
+++ b/drive/include/swerve_module.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <vector2d.hpp>
 #include <cmath>
 #include <libhal-actuator/smart_servo/rmd/mc_x_v2.hpp>
 #include <libhal-arm-mcu/stm32f1/input_pin.hpp>
@@ -10,6 +9,7 @@
 #include <libhal/steady_clock.hpp>
 #include <libhal/units.hpp>
 #include <swerve_structs.hpp>
+#include <vector2d.hpp>
 
 namespace sjsu::drive {
 
@@ -33,7 +33,8 @@ struct swerve_module_settings
   bool drive_forward_clockwise = true;
 };
 
-enum async_home_status {
+enum async_home_status
+{
   inactive,
   in_progress,
   completed,

--- a/drive/src/drivetrain.cpp
+++ b/drive/src/drivetrain.cpp
@@ -180,21 +180,23 @@ bool drivetrain::aligned()
   }
   return true;
 }
-void drivetrain::hard_home(hal::v5::strong_ptr<hal::steady_clock> clock)
+void drivetrain::hard_home(hal::v5::strong_ptr<hal::steady_clock> p_clock)
 {
   for (auto& m : *m_modules) {
     m->async_home_begin();
   }
   bool done = true;
   while (true) {
-    if (m->async_home_poll() == async_home_status::in_progress) {
-      done = false;
+    for (auto& m : *m_modules) {
+      if (m->async_home_poll() == async_home_status::in_progress) {
+        done = false;
+      }
     }
     if (done) {
       break;
     }
     // seems safe
-    hal::delay(*clock, 250ms);
+    hal::delay(*p_clock, 250ms);
   }
 }
 void drivetrain::async_home_begin()

--- a/drive/src/drivetrain.cpp
+++ b/drive/src/drivetrain.cpp
@@ -172,17 +172,17 @@ bool drivetrain::aligned()
   }
   return true;
 }
-void drivetrain::hard_home_begin()
+void drivetrain::async_home_begin()
 {
   for (auto& m : *m_modules) {
-    m->hard_home_begin();
+    m->async_home_begin();
   }
 }
-bool drivetrain::hard_home_poll()
+bool drivetrain::async_home_poll()
 {
   bool complete = true;
   for (auto& m : *m_modules) {
-    if (m->hard_home_poll() == hard_home_status::in_progress) {
+    if (m->async_home_poll() == async_home_status::in_progress) {
       complete = false;
     }
   }

--- a/drive/src/drivetrain.cpp
+++ b/drive/src/drivetrain.cpp
@@ -188,5 +188,11 @@ bool drivetrain::async_home_poll()
   }
   return complete;
 }
+void drivetrain::async_home_stop()
+{
+  for (auto& m : *m_modules) {
+    m->async_home_stop();
+  }
+}
 
 }  // namespace sjsu::drive

--- a/drive/src/drivetrain.cpp
+++ b/drive/src/drivetrain.cpp
@@ -1,10 +1,10 @@
-#include <resource_list.hpp>
-#include <vector2d.hpp>
 #include <array>
 #include <drivetrain.hpp>
 #include <drivetrain_math.hpp>
 #include <libhal-util/serial.hpp>
+#include <resource_list.hpp>
 #include <swerve_module.hpp>
+#include <vector2d.hpp>
 
 namespace sjsu::drive {
 
@@ -27,7 +27,7 @@ bool drivetrain::set_target_state(chassis_velocities p_target_state,
   bool can_reach = true;
   auto console = resources::console();
   for (vector2d v : vectors) {
-    hal::print<128>(*console,"vec:%f,%f\n",v.x,v.y);
+    hal::print<128>(*console, "vec:%f,%f\n", v.x, v.y);
   }
 
   for (int i = 0; can_reach && i < module_count; i++) {
@@ -57,7 +57,8 @@ bool drivetrain::set_target_state(chassis_velocities p_target_state,
   }
   return can_reach;
 }
-chassis_velocities drivetrain::get_target_state() {
+chassis_velocities drivetrain::get_target_state()
+{
   return m_target_state;
 }
 
@@ -78,6 +79,9 @@ void drivetrain::periodic()
   if (drive_stopped) {
     m_stopping = false;
   }
+
+  // poll homing
+  async_home_poll();
 
   std::array<swerve_module_state, module_count> next_target_states;
   // if stopping slow down
@@ -121,8 +125,8 @@ void drivetrain::periodic()
   }
 
   // interpolate into modules next target_states
-  next_target_states = interpolate_states(
-    m_refresh_rate, *m_modules, next_target_states);
+  next_target_states =
+    interpolate_states(m_refresh_rate, *m_modules, next_target_states);
   for (int i = 0; i < module_count; i++) {
     swerve_module& module = *(m_modules->at(i));
     module.set_target_state(next_target_states[i]);
@@ -178,15 +182,11 @@ void drivetrain::async_home_begin()
     m->async_home_begin();
   }
 }
-bool drivetrain::async_home_poll()
+void drivetrain::async_home_poll()
 {
-  bool complete = true;
   for (auto& m : *m_modules) {
-    if (m->async_home_poll() == async_home_status::in_progress) {
-      complete = false;
-    }
+    m->async_home_poll();
   }
-  return complete;
 }
 void drivetrain::async_home_stop()
 {

--- a/drive/src/drivetrain.cpp
+++ b/drive/src/drivetrain.cpp
@@ -180,6 +180,23 @@ bool drivetrain::aligned()
   }
   return true;
 }
+void drivetrain::hard_home(hal::v5::strong_ptr<hal::steady_clock> clock)
+{
+  for (auto& m : *m_modules) {
+    m->async_home_begin();
+  }
+  bool done = true;
+  while (true) {
+    if (m->async_home_poll() == async_home_status::in_progress) {
+      done = false;
+    }
+    if (done) {
+      break;
+    }
+    // seems safe
+    hal::delay(*clock, 250ms);
+  }
+}
 void drivetrain::async_home_begin()
 {
   for (auto& m : *m_modules) {

--- a/drive/src/drivetrain.cpp
+++ b/drive/src/drivetrain.cpp
@@ -28,7 +28,7 @@ bool drivetrain::set_target_state(chassis_velocities p_target_state,
   auto console = resources::console();
   for (vector2d v : vectors) {
     hal::print<128>(*console,"vec:%f,%f\n",v.x,v.y);
-  }  
+  }
 
   for (int i = 0; can_reach && i < module_count; i++) {
     m_final_target_module_states[i] =
@@ -119,7 +119,7 @@ void drivetrain::periodic()
       next_target_states = m_final_target_module_states;
     }
   }
-  
+
   // interpolate into modules next target_states
   next_target_states = interpolate_states(
     m_refresh_rate, *m_modules, next_target_states);
@@ -172,11 +172,21 @@ bool drivetrain::aligned()
   }
   return true;
 }
-void drivetrain::hard_home()
+void drivetrain::hard_home_begin()
 {
   for (auto& m : *m_modules) {
-    m->hard_home();
+    m->hard_home_begin();
   }
+}
+bool drivetrain::hard_home_poll()
+{
+  bool complete = true;
+  for (auto& m : *m_modules) {
+    if (m->hard_home_poll() == hard_home_status::in_progress) {
+      complete = false;
+    }
+  }
+  return complete;
 }
 
 }  // namespace sjsu::drive

--- a/drive/src/swerve_module.cpp
+++ b/drive/src/swerve_module.cpp
@@ -197,4 +197,10 @@ async_home_status swerve_module::async_home_poll()
   return async_home_status::completed;
 }
 
+void swerve_module::async_home_stop()
+{
+  m_steer_motor->velocity_control(0);
+  m_async_homing_state = false;
+}
+
 }  // namespace sjsu::drive

--- a/drive/src/swerve_module.cpp
+++ b/drive/src/swerve_module.cpp
@@ -149,7 +149,7 @@ bool swerve_module::tolerance_timed_out() const
 void swerve_module::async_home_begin()
 {
   auto console = resources::console();
-  if (m_hard_homing_state) {
+  if (m_async_homing_state) {
     hal::print(*console, "already homing module!\n");
     return;
   }
@@ -167,12 +167,12 @@ void swerve_module::async_home_begin()
     m_steer_motor->velocity_control(1);
   }
 
-  m_hard_homing_state = true;
+  m_async_homing_state = true;
 }
 
 async_home_status swerve_module::async_home_poll()
 {
-  if (!m_hard_homing_state) {
+  if (!m_async_homing_state) {
     return async_home_status::inactive;
   }
   if (!m_limit_switch->level()) {
@@ -193,7 +193,7 @@ async_home_status swerve_module::async_home_poll()
   //   *console, "fin position: %f\n",
   //   refresh_actual_state_cache().steer_angle);
 
-  m_hard_homing_state = false;
+  m_async_homing_state = false;
   return async_home_status::completed;
 }
 

--- a/drive/src/swerve_module.cpp
+++ b/drive/src/swerve_module.cpp
@@ -1,5 +1,4 @@
 #include "../include/swerve_module.hpp"
-#include <resource_list.hpp>
 #include <cmath>
 #include <cstdlib>
 #include <drivetrain_math.hpp>
@@ -147,13 +146,19 @@ bool swerve_module::tolerance_timed_out() const
   return m_stable_tolerance_state;
 }
 
-void swerve_module::hard_home()
+void swerve_module::hard_home_begin()
 {
   auto console = resources::console();
+  if (m_hard_homing_state) {
+    hal::print(*console, "already homing module!\n");
+    return;
+  }
+
   hal::print(*console, "starting hard home changed\n");
   m_steer_motor->feedback_request(
     hal::actuator::rmd_mc_x_v2::read::multi_turns_angle);
   m_steer_motor->velocity_control(0);  // dummy message
+                                       //
   hal::print<128>(*console, "Start level: %d\n", m_limit_switch->level());
   [[__maybe_unused__]] float start_angle = m_steer_motor->feedback().angle();
   if (settings.home_clockwise) {
@@ -161,9 +166,20 @@ void swerve_module::hard_home()
   } else {
     m_steer_motor->velocity_control(1);
   }
-  // while (m_limit_switch->level()) {
-  //   hal::delay(*m_clock, 250ms);  // 250ms seams safe refresh time
-  // }
+
+  m_hard_homing_state = true;
+}
+
+hard_home_status swerve_module::hard_home_poll()
+{
+  if (!m_hard_homing_state) {
+    return hard_home_status::inactive;
+  }
+  if (!m_limit_switch->level()) {
+    return hard_home_status::in_progress;
+  }
+
+  auto console = resources::console();
   m_steer_motor->velocity_control(0);  // stops
   hal::print<128>(*console, "Final level: %d\n", m_limit_switch->level());
 
@@ -176,6 +192,9 @@ void swerve_module::hard_home()
   // hal::print<128>(
   //   *console, "fin position: %f\n",
   //   refresh_actual_state_cache().steer_angle);
+
+  m_hard_homing_state = false;
+  return hard_home_status::completed;
 }
 
 }  // namespace sjsu::drive

--- a/drive/src/swerve_module.cpp
+++ b/drive/src/swerve_module.cpp
@@ -146,7 +146,7 @@ bool swerve_module::tolerance_timed_out() const
   return m_stable_tolerance_state;
 }
 
-void swerve_module::hard_home_begin()
+void swerve_module::async_home_begin()
 {
   auto console = resources::console();
   if (m_hard_homing_state) {
@@ -170,13 +170,13 @@ void swerve_module::hard_home_begin()
   m_hard_homing_state = true;
 }
 
-hard_home_status swerve_module::hard_home_poll()
+async_home_status swerve_module::async_home_poll()
 {
   if (!m_hard_homing_state) {
-    return hard_home_status::inactive;
+    return async_home_status::inactive;
   }
   if (!m_limit_switch->level()) {
-    return hard_home_status::in_progress;
+    return async_home_status::in_progress;
   }
 
   auto console = resources::console();
@@ -194,7 +194,7 @@ hard_home_status swerve_module::hard_home_poll()
   //   refresh_actual_state_cache().steer_angle);
 
   m_hard_homing_state = false;
-  return hard_home_status::completed;
+  return async_home_status::completed;
 }
 
 }  // namespace sjsu::drive


### PR DESCRIPTION
Refactored the `hard_home()` method to be asynchronous in `swerve_module` and `drive_train` by splitting it into two methods:

For `swerve_module`:

1. `async_home_begin()` which will begin hard homing on the swerve module.
2. `async_home_poll()` which will poll the hard homing state on the swerve module, one of `inactive`, `in_progress`, and `completed`. The logic to stop the swerve module is contained within `async_home_poll()`, `completed` will be returned when the limit switch is active and the swerve module is stopped, after which `inactive` will be returned if hard homing is not begun again.
3. `async_home_stop()` which will immediately stop homing on the swerve module.

For `drive_train`:

1. `async_home_begin()` begins hard homing on all swerve modules.
2. `async_home_poll()` returns true if all swerve modules have finished homing or are inactive, false if at least one swerve module is still homing.
3. `async_home_stop()` which will immediately stop homing on all swerve modules.

All demos utilizing `hard_home()` have also been refactored.