### PR TITLE
Update README build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 This Repository will host the code for the new SJSU Robotics Rover.
 ## To build:
 ```
-conan build PATH -pr stm32f103c8  -pr arm-gcc-14.2 -b missing
+conan build PATH -pr:a hal/tc/gcc -pr hal/mcu/stm32f103c8 -b missing
 ```
 
-Replace `PATH` with the corelating path to subsystem or driver(s). The folder contain a `conan.py` file. 
+Replace `PATH` with the corelating path to subsystem or driver(s). The folder contain a `conan.py` file.
 
 If the conan.lock prevents you from building due to inconsequential package differences based on your system use the `--lockfile-partial` flag to bypass the lock
 
 If you are already in in the folder run (for quick copy paste):
 
 ```
-conan build . -pr stm32f103c8  -pr arm-gcc-14.2 -b missing
+conan build . -pr:a hal/tc/gcc -pr hal/mcu/stm32f103c8 -b missing
 ```
 ## To flash to controller:
 ```
@@ -34,7 +34,7 @@ If you are already in the folder and want run the main application (for quick co
 stm32loader -e -w -v -B -p /dev/tty.usbserial-## ./build/stm32f103c8/MinSizeRel/application.elf.bin
 ```
 
-**Windows:** 
+**Windows:**
 ```
 stm32loader -e -w -v -B -p COM## .\build\stm32f103c8\MinSizeRel\application.elf.bin
 ```


### PR DESCRIPTION
The build commands in the README are currently listing old Conan profiles that will cause inexplicable build issues and result in much grief, this updates the build command to use the newest profiles listed [here](https://libhal.github.io/4.3/user_guide/interfaces/#sensors).

Essentially: `-pr stm32f103c8 -pr arm-gcc-14.2` -> `-pr:a hal/tc/gcc -pr hal/mcu/stm32f103c8`.

Also, version 1.21.1 of `libhal-arm-mcu` corrects the amount of memory on the STM the linker thinks it has, it would be good to update to this version as soon as possible.