### PR TITLE
Abstract drive motor interfaces in swerve_module and chassis_vel_demo

### DIFF
--- a/drive/applications/prop_motor_test.cpp
+++ b/drive/applications/prop_motor_test.cpp
@@ -1,10 +1,14 @@
 #include <drivetrain_math.hpp>
-#include <libhal-actuator/smart_servo/rmd/mc_x_v2.hpp>
 #include <libhal-exceptions/control.hpp>
 #include <libhal-util/serial.hpp>
 #include <libhal-util/steady_clock.hpp>
 #include <libhal/error.hpp>
+#include <libhal/motor.hpp>
+#include <libhal/servo.hpp>
 #include <resource_list.hpp>
+
+// TODO: resource file must be updated to return abstract interface types
+//       (velocity_servo for steer, velocity_motor for prop) before this file will compile
 
 namespace sjsu::drive {
 void application()
@@ -12,51 +16,54 @@ void application()
   auto clock = resources::clock();
   auto console = resources::console();
   hal::print(*console, "app starting\n");
-  hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> steer_motor_array[] = {
+  // TODO: resource file must return hal::velocity_servo instead of rmd_mc_x_v2
+  hal::v5::strong_ptr<hal::velocity_servo> steer_motor_array[] = {
     resources::front_left_steer(),
     resources::front_right_steer(),
     resources::back_left_steer(),
     resources::back_right_steer()
   };
-  std::span steer_motors = {steer_motor_array};
+  std::span steer_motors = { steer_motor_array };
+
+  // configure steer speed then lock to current position
   for (uint8_t i = 0; i < steer_motors.size(); i++) {
-    steer_motors[i]->feedback_request(
-      hal::actuator::rmd_mc_x_v2::read::multi_turns_angle);
-    float angle = steer_motors[i]->feedback().angle();
-    steer_motors[i]->position_control(angle, 120);
+    steer_motors[i]->configure({ .velocity = 120 });
+    float angle = steer_motors[i]->position();
+    steer_motors[i]->position(angle);
   }
   hal::print(*console, "steer locked\n");
 
-  hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> prop_motor_array[] = {
+  // TODO: resource file must return hal::velocity_motor instead of rmd_mc_x_v2
+  hal::v5::strong_ptr<hal::velocity_motor> prop_motor_array[] = {
     resources::front_left_prop(),
     resources::front_right_prop(),
     resources::back_left_prop(),
     resources::back_right_prop()
   };
-  std::span prop_motors{prop_motor_array};
+  std::span prop_motors{ prop_motor_array };
   hal::delay(*clock, 3s);
   hal::print(*console, "forward\n");
   float rpm = 20;
   for (uint8_t i = 0; i < prop_motors.size(); i++) {
     if (i % 2) {
-      prop_motors[i]->velocity_control(rpm);
+      prop_motors[i]->drive(rpm);
     } else {
-      prop_motors[i]->velocity_control(-rpm);
+      prop_motors[i]->drive(-rpm);
     }
   }
   hal::delay(*clock, 8s);
   hal::print(*console, "backward\n");
   for (uint8_t i = 0; i < prop_motors.size(); i++) {
     if (i % 2) {
-      prop_motors[i]->velocity_control(-rpm);
+      prop_motors[i]->drive(-rpm);
     } else {
-      prop_motors[i]->velocity_control(rpm);
+      prop_motors[i]->drive(rpm);
     }
   }
   hal::delay(*clock, 8s);
   hal::print(*console, "Fin\n");
   for (uint8_t i = 0; i < prop_motors.size(); i++) {
-    prop_motors[i]->velocity_control(0);
+    prop_motors[i]->drive(0);
   }
 }
 }  // namespace sjsu::drive

--- a/drive/include/swerve_module.hpp
+++ b/drive/include/swerve_module.hpp
@@ -130,9 +130,9 @@ private:
   // velocity_servo handles normal steer operation: position set + position read
   hal::v5::strong_ptr<hal::velocity_servo> m_steer_servo;
   // velocity_motor handles steer homing: free spin until limit switch triggers
-  // TODO: resource file must provide both m_steer_servo and m_steer_homing_motor
+  // TODO: resource file must provide both m_steer_servo and m_homing_motor
   //       as two interface views of the same underlying steer motor hardware
-  hal::v5::strong_ptr<hal::velocity_motor> m_steer_homing_motor;
+  hal::v5::strong_ptr<hal::velocity_motor> m_steer_motor;
   hal::v5::strong_ptr<hal::velocity_motor> m_prop_motor;
   hal::v5::strong_ptr<hal::input_pin> m_limit_switch;
   hal::v5::strong_ptr<hal::steady_clock> m_clock;

--- a/drive/include/swerve_module.hpp
+++ b/drive/include/swerve_module.hpp
@@ -2,8 +2,8 @@
 
 #include <vector2d.hpp>
 #include <cmath>
-#include <libhal-actuator/smart_servo/rmd/mc_x_v2.hpp>
 #include <libhal-arm-mcu/stm32f1/input_pin.hpp>
+#include <libhal/motor.hpp>
 #include <libhal/pointers.hpp>
 #include <libhal/serial.hpp>
 #include <libhal/servo.hpp>
@@ -39,13 +39,17 @@ public:
   swerve_module_settings settings;
 
   /**
-   * @param p_steer_motor the motor used to control
-   * @param p_propulsion_motor the motor
-   * @param p_setting module config info
+   * @param p_steer_servo velocity servo for steer position control and feedback
+   * @param p_steer_homing_motor velocity motor for steer homing free spin
+   * @param p_prop_motor velocity motor for propulsion velocity control
+   * @param p_limit_switch limit switch for homing
+   * @param p_clock steady clock
+   * @param p_settings module config info
    */
   swerve_module(
-    hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> p_steer_motor,
-    hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> p_propulsion_motor,
+    hal::v5::strong_ptr<hal::velocity_servo> p_steer_servo,
+    hal::v5::strong_ptr<hal::velocity_motor> p_steer_homing_motor,
+    hal::v5::strong_ptr<hal::velocity_motor> p_prop_motor,
     hal::v5::strong_ptr<hal::input_pin> p_limit_switch,
     hal::v5::strong_ptr<hal::steady_clock> p_clock,
     swerve_module_settings p_settings);
@@ -114,17 +118,22 @@ public:
    * @return returns encoder reading in degrees when facing forward
    */
   float get_steer_offset();
-  
+
 private:
   hal::degrees get_steer_motor_position();
   void set_steer_motor_position(hal::degrees p_position);
-  void set_steer_motor_velocity(float p_velocity);
-  
-  float get_prop_motor_velocity();
-  void set_prop_motor_velocity(float p_velocity);
+  void set_steer_motor_velocity(hal::rpm p_velocity);
 
-  hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> m_steer_motor;
-  hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> m_propulsion_motor;
+  hal::rpm get_prop_motor_velocity();
+  void set_prop_motor_velocity(hal::rpm p_velocity);
+
+  // velocity_servo handles normal steer operation: position set + position read
+  hal::v5::strong_ptr<hal::velocity_servo> m_steer_servo;
+  // velocity_motor handles steer homing: free spin until limit switch triggers
+  // TODO: resource file must provide both m_steer_servo and m_steer_homing_motor
+  //       as two interface views of the same underlying steer motor hardware
+  hal::v5::strong_ptr<hal::velocity_motor> m_steer_homing_motor;
+  hal::v5::strong_ptr<hal::velocity_motor> m_prop_motor;
   hal::v5::strong_ptr<hal::input_pin> m_limit_switch;
   hal::v5::strong_ptr<hal::steady_clock> m_clock;
   swerve_module_state m_target_state;
@@ -135,7 +144,5 @@ private:
   hal::time_duration m_tolerance_last_changed = 0ns;
   // true = out of tolerance
   bool m_stable_tolerance_state = false;
-
-private:
 };
 }  // namespace sjsu::drive

--- a/drive/src/swerve_module.cpp
+++ b/drive/src/swerve_module.cpp
@@ -23,7 +23,7 @@ swerve_module::swerve_module(
   swerve_module_settings p_settings)
   : settings(p_settings)
   , m_steer_servo(p_steer_servo)
-  , m_steer_homing_motor(p_steer_homing_motor)
+  , m_steer_motor(p_steer_homing_motor)
   , m_prop_motor(p_prop_motor)
   , m_limit_switch(p_limit_switch)
   , m_clock(p_clock)
@@ -252,7 +252,7 @@ void swerve_module::set_steer_motor_velocity(hal::rpm p_velocity)
   while (true) {
     hal::print(*console, "tg_steer_vel");
     try {
-      m_steer_homing_motor->drive(p_velocity);
+      m_steer_motor->drive(p_velocity);
       return;
     } catch (hal::exception e) {
       attempts--;

--- a/drive/src/swerve_module.cpp
+++ b/drive/src/swerve_module.cpp
@@ -15,17 +15,21 @@ using namespace hal::literals;
 namespace sjsu::drive {
 
 swerve_module::swerve_module(
-  hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> p_steer_motor,
-  hal::v5::strong_ptr<hal::actuator::rmd_mc_x_v2> p_propulsion_motor,
+  hal::v5::strong_ptr<hal::velocity_servo> p_steer_servo,
+  hal::v5::strong_ptr<hal::velocity_motor> p_steer_homing_motor,
+  hal::v5::strong_ptr<hal::velocity_motor> p_prop_motor,
   hal::v5::strong_ptr<hal::input_pin> p_limit_switch,
   hal::v5::strong_ptr<hal::steady_clock> p_clock,
   swerve_module_settings p_settings)
   : settings(p_settings)
-  , m_steer_motor(p_steer_motor)
-  , m_propulsion_motor(p_propulsion_motor)
+  , m_steer_servo(p_steer_servo)
+  , m_steer_homing_motor(p_steer_homing_motor)
+  , m_prop_motor(p_prop_motor)
   , m_limit_switch(p_limit_switch)
   , m_clock(p_clock)
 {
+  // configure steer servo velocity (previously hardcoded as 30 in position_control)
+  m_steer_servo->configure({ .velocity = 30 });
   // TODO: verify settings were initalized
 }
 
@@ -211,10 +215,7 @@ hal::degrees swerve_module::get_steer_motor_position()
   while (true) {
     try {
       hal::print(*console, "tg_steer");
-      m_steer_motor->feedback_request(
-        hal::actuator::rmd_mc_x_v2::read::multi_turns_angle);
-      auto angle = m_steer_motor->feedback().angle();
-      return angle;
+      return m_steer_servo->position();
     } catch (hal::exception e) {
       attempts--;
       if (attempts <= 0) {
@@ -224,6 +225,7 @@ hal::degrees swerve_module::get_steer_motor_position()
     }
   }
 }
+
 void swerve_module::set_steer_motor_position(hal::degrees p_position)
 {
   auto console = resources::console();
@@ -231,25 +233,7 @@ void swerve_module::set_steer_motor_position(hal::degrees p_position)
   while (true) {
     hal::print(*console, "ts_steer");
     try {
-      m_steer_motor->position_control(p_position, 30);
-      return;
-    } catch (hal::exception e) {
-      attempts--;
-      if (attempts <= 0) {
-        hal::print(*console, "final attempt failed throwing");
-        throw;
-      }
-    }
-  }
-}
-void swerve_module::set_steer_motor_velocity(float p_velocity)
-{
-  auto console = resources::console();
-  int attempts = can_attempts;
-  while (true) {
-    hal::print(*console, "tg_steer_vel");
-    try {
-      m_steer_motor->velocity_control(p_velocity);
+      m_steer_servo->position(p_position);
       return;
     } catch (hal::exception e) {
       attempts--;
@@ -261,14 +245,33 @@ void swerve_module::set_steer_motor_velocity(float p_velocity)
   }
 }
 
-float swerve_module::get_prop_motor_velocity()
+void swerve_module::set_steer_motor_velocity(hal::rpm p_velocity)
+{
+  auto console = resources::console();
+  int attempts = can_attempts;
+  while (true) {
+    hal::print(*console, "tg_steer_vel");
+    try {
+      m_steer_homing_motor->drive(p_velocity);
+      return;
+    } catch (hal::exception e) {
+      attempts--;
+      if (attempts <= 0) {
+        hal::print(*console, "final attempt failed throwing");
+        throw;
+      }
+    }
+  }
+}
+
+hal::rpm swerve_module::get_prop_motor_velocity()
 {
   int attempts = can_attempts;
   auto console = resources::console();
   while (true) {
     hal::print(*console, "tg_prop");
     try {
-      return m_propulsion_motor->feedback().speed();
+      return m_prop_motor->status().velocity;
     } catch (hal::exception e) {
       attempts--;
       if (attempts <= 0) {
@@ -279,14 +282,15 @@ float swerve_module::get_prop_motor_velocity()
     }
   }
 }
-void swerve_module::set_prop_motor_velocity(float p_velocity)
+
+void swerve_module::set_prop_motor_velocity(hal::rpm p_velocity)
 {
   auto console = resources::console();
   int attempts = can_attempts;
   while (true) {
     hal::print(*console, "ts_prop");
     try {
-      m_propulsion_motor->velocity_control(p_velocity);
+      m_prop_motor->drive(p_velocity);
       return;
     } catch (hal::exception e) {
       attempts--;


### PR DESCRIPTION
Closes #105

Changes
Updated `swerve_module.hpp`, `swerve_module.cpp`, and `chassis_vel_demo.cpp` to use abstract libhal interfaces instead of `rmd_mc_x_v2` directly.

Interfaces Used
- `hal::velocity_servo` for the steer motor during normal driving, it handles setting and reading position
- `hal::velocity_motor` for the steer motor during homing, it handles free spinning until the limit switch triggers
- `hal::velocity_motor` for the propulsion motor, it handles setting and reading velocity

The steer motor used two separate interface pointers because it does two different things: position control during normal operation, and free spinning during homing.

Not Changed
- `can_stability_test.cpp` and `poll_motor_connections.cpp` were left unchanged even though they had RMD stuff in it. These files use `feedback_request` to send raw CAN messages to test if motors are connected and responding. I'm pretty sure this is RMD-specific behavior, and I could not find an abstract equivalent, so changing these files would probably break what they are designed to test.
- The resource file was not updated because you mentioned that I didn't need to do that right now. TODOs have also been added in the relevant files saying where the resource file needs to be updated.