### PR TITLE
update libhal-arm-mcu to 1.21.2

### DIFF
--- a/drive/conan.lock
+++ b/drive/conan.lock
@@ -1,0 +1,30 @@
+{
+    "version": "0.5",
+    "requires": [
+        "tl-function-ref/1.0.0#8efcfa342c5169b3c260a290257d7eee%1685725656.215",
+        "scope-lite/0.2.0#3d661c43163ac4ebc53ec5e3f9e77490%1661467774.415",
+        "ring-span-lite/0.7.0#73c13ef86652f52ad6b52048b15af784%1716299614.015",
+        "prebuilt-picolibc/14#976aa3ceea36f69f8c3713efee7fea79%1771169549.521",
+        "libhal-util/5.8.1#dca6ef7baf4f47bcc0eba9baf3c7dbf1%1761614359.953",
+        "libhal-mock/4.0.0#e2a2cc593adc03806c6a8b80c5a89638%1715616381.717",
+        "libhal-arm-mcu/1.21.2#ae0a97b5e8a240d7680e3d9363729b61%1776466111.1",
+        "libhal-actuator/1.2.3#c9604e30af20eb688d32b6a6440ad6ea%1761181221.054",
+        "libhal/4.18.1#8d15efecea9aadb357c23770627b0341%1761511486.387",
+        "boost-ext-ut/2.3.1#e0a2761f845926e65a8aee07e3995ed5%1749912869.147",
+        "boost-ext-ut/2.1.0#aec3873a3273d96f85093971c6c8b206%1749912871.352",
+        "boost-ext-ut/1.1.9#09b31ef61352d71b2a4374caa826d485%1749912876.292"
+    ],
+    "build_requires": [
+        "ninja/1.13.2#c8c5dc2a52ed6e4e42a66d75b4717ceb%1764096931.974",
+        "multiarch-gnu-toolchain/14#dd685a11b603d4d1f8f6669690bc7a71%1769713896.773",
+        "make/4.4.1#c47f1ee3241ca8bd56f97c6ca4d0a082%1703967201.413",
+        "libhal-cmake-util/4.4.4#4a5486fc59453c3deae46396f218813c%1770089422.376",
+        "cmake/4.3.2#c740c22f711eb5ef0cec51c40b84657b%1776934625.055",
+        "cmake/3.27.1#7d5f14447c023feef9f59640be53619a%1691315387.882"
+    ],
+    "python_requires": [
+        "libhal-bootstrap/4.6.1#86fb510b6d787a1d12197befd98b5cac%1765569402.933",
+        "libhal-bootstrap/4.3.0#bf1b8f851221d7b59695e4267eecafe8%1748368690.981"
+    ],
+    "config_requires": []
+}

--- a/drive/conanfile.py
+++ b/drive/conanfile.py
@@ -9,5 +9,5 @@ class demos(ConanFile):
     def requirements(self):
         self.requires("libhal/4.18.1")
         self.requires("libhal-util/5.8.1")
-        self.requires("libhal-arm-mcu/1.19.6")
+        self.requires("libhal-arm-mcu/1.21.2")
         self.requires("libhal-actuator/1.2.3")

--- a/drivers/conan.lock
+++ b/drivers/conan.lock
@@ -1,0 +1,29 @@
+{
+    "version": "0.5",
+    "requires": [
+        "tl-function-ref/1.0.0#8efcfa342c5169b3c260a290257d7eee%1685725656.215",
+        "scope-lite/0.2.0#3d661c43163ac4ebc53ec5e3f9e77490%1661467774.415",
+        "ring-span-lite/0.7.0#73c13ef86652f52ad6b52048b15af784%1716299614.015",
+        "prebuilt-picolibc/14#976aa3ceea36f69f8c3713efee7fea79%1771169549.521",
+        "libhal-util/5.8.1#dca6ef7baf4f47bcc0eba9baf3c7dbf1%1761614359.953",
+        "libhal-mock/4.0.0#e2a2cc593adc03806c6a8b80c5a89638%1715616381.717",
+        "libhal-arm-mcu/1.21.2#ae0a97b5e8a240d7680e3d9363729b61%1776466111.1",
+        "libhal/4.21.0#f8715ee339306248b3a9c28467a8d1a3%1773358772.954",
+        "boost-ext-ut/2.3.1#e0a2761f845926e65a8aee07e3995ed5%1749912869.147",
+        "boost-ext-ut/2.1.0#aec3873a3273d96f85093971c6c8b206%1749912871.352",
+        "boost-ext-ut/1.1.9#09b31ef61352d71b2a4374caa826d485%1749912876.292"
+    ],
+    "build_requires": [
+        "ninja/1.13.2#c8c5dc2a52ed6e4e42a66d75b4717ceb%1764096931.974",
+        "multiarch-gnu-toolchain/14#dd685a11b603d4d1f8f6669690bc7a71%1769713896.773",
+        "make/4.4.1#c47f1ee3241ca8bd56f97c6ca4d0a082%1703967201.413",
+        "libhal-cmake-util/4.4.4#4a5486fc59453c3deae46396f218813c%1770089422.376",
+        "cmake/4.3.2#c740c22f711eb5ef0cec51c40b84657b%1776934625.055",
+        "cmake/3.27.1#7d5f14447c023feef9f59640be53619a%1691315387.882"
+    ],
+    "python_requires": [
+        "libhal-bootstrap/4.6.1#86fb510b6d787a1d12197befd98b5cac%1765569402.933",
+        "libhal-bootstrap/4.3.0#bf1b8f851221d7b59695e4267eecafe8%1748368690.981"
+    ],
+    "config_requires": []
+}

--- a/drivers/conanfile.py
+++ b/drivers/conanfile.py
@@ -23,4 +23,4 @@ class demos(ConanFile):
 
     def requirements(self):
         self.requires("libhal-util/5.8.1")
-        self.requires("libhal-arm-mcu/1.19.6")
+        self.requires("libhal-arm-mcu/1.21.2")

--- a/hub/conan.lock
+++ b/hub/conan.lock
@@ -1,0 +1,30 @@
+{
+    "version": "0.5",
+    "requires": [
+        "tl-function-ref/1.0.0#8efcfa342c5169b3c260a290257d7eee%1685725656.215",
+        "scope-lite/0.2.0#3d661c43163ac4ebc53ec5e3f9e77490%1661467774.415",
+        "ring-span-lite/0.7.0#73c13ef86652f52ad6b52048b15af784%1716299614.015",
+        "prebuilt-picolibc/14.2#197a708367ee7d3b9e9057bf9bd0eaa2%1747924705.981",
+        "prebuilt-picolibc/14#976aa3ceea36f69f8c3713efee7fea79%1771169549.521",
+        "libhal-util/5.8.1#dca6ef7baf4f47bcc0eba9baf3c7dbf1%1761614359.953",
+        "libhal-mock/4.0.0#e2a2cc593adc03806c6a8b80c5a89638%1715616381.717",
+        "libhal-arm-mcu/1.21.2#ae0a97b5e8a240d7680e3d9363729b61%1776466111.1",
+        "libhal-arm-mcu/1.19.6#54553cd730a92e3c11da7924a5c149a6%1766154640.666",
+        "libhal/4.18.1#8d15efecea9aadb357c23770627b0341%1761511486.387",
+        "boost-ext-ut/2.1.0#aec3873a3273d96f85093971c6c8b206%1749912871.352",
+        "boost-ext-ut/1.1.9#09b31ef61352d71b2a4374caa826d485%1749912876.292"
+    ],
+    "build_requires": [
+        "multiarch-gnu-toolchain/14#dd685a11b603d4d1f8f6669690bc7a71%1769713896.773",
+        "make/4.4.1#c47f1ee3241ca8bd56f97c6ca4d0a082%1703967201.413",
+        "libhal-cmake-util/4.3.3#5ce59d550ca2dfc35a98c822280aa0ed%1748119871.017",
+        "cmake/4.3.2#c740c22f711eb5ef0cec51c40b84657b%1776934625.055",
+        "cmake/3.27.1#7d5f14447c023feef9f59640be53619a%1691315387.882",
+        "arm-gnu-toolchain/14.2#d2e6094d38b1736e6553453c5ef3e0f8%1748977405.812"
+    ],
+    "python_requires": [
+        "libhal-bootstrap/4.5.0#3be6ef595aec847c099257ec1250b3ec%1751767039.907",
+        "libhal-bootstrap/4.3.0#bf1b8f851221d7b59695e4267eecafe8%1748368690.981"
+    ],
+    "config_requires": []
+}

--- a/hub/conanfile.py
+++ b/hub/conanfile.py
@@ -23,4 +23,4 @@ class demos(ConanFile):
 
     def requirements(self):
         self.requires("libhal-util/5.8.1")
-        self.requires("libhal-arm-mcu/1.19.6")
+        self.requires("libhal-arm-mcu/1.21.2")

--- a/perseus/conan.lock
+++ b/perseus/conan.lock
@@ -1,0 +1,30 @@
+{
+    "version": "0.5",
+    "requires": [
+        "tl-function-ref/1.0.0#8efcfa342c5169b3c260a290257d7eee%1685725656.215",
+        "scope-lite/0.2.0#3d661c43163ac4ebc53ec5e3f9e77490%1661467774.415",
+        "ring-span-lite/0.7.0#73c13ef86652f52ad6b52048b15af784%1716299614.015",
+        "prebuilt-picolibc/14.2#197a708367ee7d3b9e9057bf9bd0eaa2%1747924705.981",
+        "prebuilt-picolibc/14#976aa3ceea36f69f8c3713efee7fea79%1771169549.521",
+        "libhal-util/5.8.1#dca6ef7baf4f47bcc0eba9baf3c7dbf1%1761614359.953",
+        "libhal-mock/4.0.0#e2a2cc593adc03806c6a8b80c5a89638%1715616381.717",
+        "libhal-arm-mcu/1.21.2#ae0a97b5e8a240d7680e3d9363729b61%1776466111.1",
+        "libhal-arm-mcu/1.19.6#54553cd730a92e3c11da7924a5c149a6%1766154640.666",
+        "libhal/4.18.1#8d15efecea9aadb357c23770627b0341%1761511486.387",
+        "boost-ext-ut/2.1.0#aec3873a3273d96f85093971c6c8b206%1749912871.352",
+        "boost-ext-ut/1.1.9#09b31ef61352d71b2a4374caa826d485%1749912876.292"
+    ],
+    "build_requires": [
+        "multiarch-gnu-toolchain/14#dd685a11b603d4d1f8f6669690bc7a71%1769713896.773",
+        "make/4.4.1#c47f1ee3241ca8bd56f97c6ca4d0a082%1703967201.413",
+        "libhal-cmake-util/4.3.3#5ce59d550ca2dfc35a98c822280aa0ed%1748119871.017",
+        "cmake/4.3.2#c740c22f711eb5ef0cec51c40b84657b%1776934625.055",
+        "cmake/3.27.1#7d5f14447c023feef9f59640be53619a%1691315387.882",
+        "arm-gnu-toolchain/14.2#d2e6094d38b1736e6553453c5ef3e0f8%1748977405.812"
+    ],
+    "python_requires": [
+        "libhal-bootstrap/4.5.0#3be6ef595aec847c099257ec1250b3ec%1751767039.907",
+        "libhal-bootstrap/4.3.0#bf1b8f851221d7b59695e4267eecafe8%1748368690.981"
+    ],
+    "config_requires": []
+}

--- a/perseus/conanfile.py
+++ b/perseus/conanfile.py
@@ -23,4 +23,4 @@ class demos(ConanFile):
 
     def requirements(self):
         self.requires("libhal-util/5.8.1")
-        self.requires("libhal-arm-mcu/1.19.6")
+        self.requires("libhal-arm-mcu/1.21.2")

--- a/science/conan.lock
+++ b/science/conan.lock
@@ -1,0 +1,32 @@
+{
+    "version": "0.5",
+    "requires": [
+        "tl-function-ref/1.0.0#8efcfa342c5169b3c260a290257d7eee%1685725656.215",
+        "scope-lite/0.2.0#3d661c43163ac4ebc53ec5e3f9e77490%1661467774.415",
+        "ring-span-lite/0.7.0#73c13ef86652f52ad6b52048b15af784%1716299614.015",
+        "prebuilt-picolibc/14.2#197a708367ee7d3b9e9057bf9bd0eaa2%1747924705.981",
+        "prebuilt-picolibc/14#976aa3ceea36f69f8c3713efee7fea79%1771169549.521",
+        "libhal-util/5.8.1#dca6ef7baf4f47bcc0eba9baf3c7dbf1%1761614359.953",
+        "libhal-mock/4.0.0#e2a2cc593adc03806c6a8b80c5a89638%1715616381.717",
+        "libhal-expander/1.3.1#bd33b60a0c32a42ea76cc62c7a8c0b7a%1764274810.099",
+        "libhal-arm-mcu/1.21.2#ae0a97b5e8a240d7680e3d9363729b61%1776466111.1",
+        "libhal-arm-mcu/1.19.6#54553cd730a92e3c11da7924a5c149a6%1766154640.666",
+        "libhal-actuator/1.2.3#c9604e30af20eb688d32b6a6440ad6ea%1761181221.054",
+        "libhal/4.18.1#8d15efecea9aadb357c23770627b0341%1761511486.387",
+        "boost-ext-ut/2.1.0#aec3873a3273d96f85093971c6c8b206%1749912871.352",
+        "boost-ext-ut/1.1.9#09b31ef61352d71b2a4374caa826d485%1749912876.292"
+    ],
+    "build_requires": [
+        "multiarch-gnu-toolchain/14#dd685a11b603d4d1f8f6669690bc7a71%1769713896.773",
+        "make/4.4.1#c47f1ee3241ca8bd56f97c6ca4d0a082%1703967201.413",
+        "libhal-cmake-util/4.3.3#5ce59d550ca2dfc35a98c822280aa0ed%1748119871.017",
+        "cmake/4.3.2#c740c22f711eb5ef0cec51c40b84657b%1776934625.055",
+        "cmake/3.27.1#7d5f14447c023feef9f59640be53619a%1691315387.882",
+        "arm-gnu-toolchain/14.2#d2e6094d38b1736e6553453c5ef3e0f8%1748977405.812"
+    ],
+    "python_requires": [
+        "libhal-bootstrap/4.5.0#3be6ef595aec847c099257ec1250b3ec%1751767039.907",
+        "libhal-bootstrap/4.3.0#bf1b8f851221d7b59695e4267eecafe8%1748368690.981"
+    ],
+    "config_requires": []
+}

--- a/science/conanfile.py
+++ b/science/conanfile.py
@@ -13,7 +13,7 @@ class demos(ConanFile):
         # self.requires("libhal-canrouter/[3.0.0]")
         self.requires("libhal/4.18.1")
         self.requires("libhal-util/5.8.1")
-        self.requires("libhal-arm-mcu/1.19.6")
+        self.requires("libhal-arm-mcu/1.21.2")
         self.requires("libhal-actuator/1.2.3")
         self.requires("libhal-expander/1.3.1")
 


### PR DESCRIPTION
update `conan.py` and `conan.lock` to use libhal-arm-mcu to 1.21.2